### PR TITLE
travis: drop go1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ go:
   - 1.5.1
   - 1.4.3
   - 1.3.3
-  - 1.2.2
 
 # let us have pretty, fast Docker-based Travis workers!
 sudo: false


### PR DESCRIPTION
seems overly reasonable to support go1.3 and greater. :-)

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>