### PR TITLE
bump version

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 // AUTO-GENEREATED. DO NOT EDIT
-// 2015-08-14 09:56:50.742727493 -0400 EDT
+// 2016-01-30 10:22:43.857076493 +0100 CET
 
-// VERSION is the generated version from /home/vbatts/src/vb/tar-split/version
-var VERSION = "v0.9.6-1-gc76e420"
+// VERSION is the generated version from /home/runcom/src/github.com/vbatts/tar-split/version
+var VERSION = "v0.9.11-1-gd50e5c9"
  


### PR DESCRIPTION
DO NOT MERGE Just a reminder cause version is pretty old compared to the tag the repo has now
If you could rebump to 0.9.12 with correct generated version I'll make sure to ship the corrected rpm in Fedora asap :)

o/ 

Signed-off-by: Antonio Murdaca <runcom@redhat.com>