### PR TITLE
travis: update golang versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,14 @@
 language: go
 go:
   - tip
-  - 1.5.1
-  - 1.4.3
-  - 1.3.3
+  - 1.6.2
+  - 1.5.4
 
 # let us have pretty, fast Docker-based Travis workers!
 sudo: false
 
 install:
   - go get -d ./...
-  - go get golang.org/x/tools/cmd/vet
 
 script:
   - go test -v ./...


### PR DESCRIPTION
This is not saying that tar-split no longer works on go1.3 or go1.4, but
rather that the headache of `go vet` having a version dependent ability
to install it, makes it a headache in travis.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>