### PR TITLE
rename github.com/Sirupsen/logrus -> github.com/sirupsen/logrus

### DIFF
--- a/cmd/tar-split/asm.go
+++ b/cmd/tar-split/asm.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"github.com/vbatts/tar-split/tar/asm"
 	"github.com/vbatts/tar-split/tar/storage"

--- a/cmd/tar-split/checksize.go
+++ b/cmd/tar-split/checksize.go
@@ -9,7 +9,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"github.com/vbatts/tar-split/tar/asm"
 	"github.com/vbatts/tar-split/tar/storage"

--- a/cmd/tar-split/disasm.go
+++ b/cmd/tar-split/disasm.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"github.com/vbatts/tar-split/tar/asm"
 	"github.com/vbatts/tar-split/tar/storage"

--- a/cmd/tar-split/main.go
+++ b/cmd/tar-split/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"github.com/vbatts/tar-split/version"
 )


### PR DESCRIPTION
Since version 1.0.0 sirupsen changed his github username to downcase.

Some references:
https://github.com/golang/dep/issues/1010
https://github.com/sirupsen/logrus/issues/570
