### PR TITLE
Add --compress flag to tar-split asm

### DIFF
--- a/cmd/tar-split/asm.go
+++ b/cmd/tar-split/asm.go
@@ -37,6 +37,12 @@ func CommandAsm(c *cli.Context) {
 		outputStream = fh
 	}
 
+	if c.Bool("compress") {
+		zipper := gzip.NewWriter(outputStream)
+		defer zipper.Close()
+		outputStream = zipper
+	}
+
 	// Get the tar metadata reader
 	mf, err := os.Open(c.String("input"))
 	if err != nil {

--- a/cmd/tar-split/main.go
+++ b/cmd/tar-split/main.go
@@ -69,6 +69,11 @@ func main() {
 					Value: "",
 					Usage: "relative path of extracted tar",
 				},
+				cli.BoolFlag{
+					Name:  "compress",
+					Usage: "gzip compress the output",
+					// defaults to false
+				},
 			},
 		},
 		{


### PR DESCRIPTION
The Go implementation of gzip is the only known to produce compressed
layers with the expected digest hashes.

This change allows compressed tar layer files to be produced, which is
useful for exporting layers from non-Go tools.