### PR TITLE
Correctly handle Read returning (0, nil)

### DIFF
--- a/tar/asm/disassemble.go
+++ b/tar/asm/disassemble.go
@@ -135,16 +135,15 @@ func NewInputTarStream(r io.Reader, p storage.Packer, fp storage.FilePutter) (io
 				}
 				isEOF = true
 			}
-			if n == 0 {
-				break
-			}
-			_, err = p.AddEntry(storage.Entry{
-				Type:    storage.SegmentType,
-				Payload: paddingChunk[:n],
-			})
-			if err != nil {
-				pW.CloseWithError(err)
-				return
+			if n != 0 {
+				_, err = p.AddEntry(storage.Entry{
+					Type:    storage.SegmentType,
+					Payload: paddingChunk[:n],
+				})
+				if err != nil {
+					pW.CloseWithError(err)
+					return
+				}
 			}
 			if isEOF {
 				break


### PR DESCRIPTION
It's not an EOF indication.

A follow-up on https://github.com/vbatts/tar-split/pull/67/files#r1271005406 .