### PR TITLE
version: bump to 0.12.0

### DIFF
--- a/cmd/tar-split/main.go
+++ b/cmd/tar-split/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-var Version = "v0.11.7"
+var Version = "v0.12.0"
 
 func main() {
 	app := cli.NewApp()


### PR DESCRIPTION
rev'ing a Y stream version because this release only has the change of making the forked version of `archive/tar` now an internal library.

Since tar-split is not even using _all_ the logic in these libraries, might as well limit folks ability to import from this aging code.

Reference: #79